### PR TITLE
fix: install victoriametrics-metrics-datasource plugin for Grafana 13

### DIFF
--- a/charts/victoriametrics/victoriametrics-values.yaml
+++ b/charts/victoriametrics/victoriametrics-values.yaml
@@ -145,6 +145,8 @@ vmsingle:
 
 grafana:
   fullnameOverride: grafana
+  plugins:
+    - victoriametrics-metrics-datasource
   # grafana.ini:
   #   auth:
   #     signout_redirect_url: "${authentik_url}/application/o/grafana/end-session/"


### PR DESCRIPTION
## Summary

- Grafana 13 (eingeführt via grafana subchart 12.3.x in victoria-metrics-k8s-stack 0.79.x)
  behandelt fehlende Plugin-Typ-Datasources als **fatalen Provisioning-Fehler** —
  Grafana 12 hat das zuvor still ignoriert
- Die Datasource `VictoriaMetrics (DS)` (`type: victoriametrics-metrics-datasource`)
  wurde immer provisioniert, das Plugin aber nie installiert → CrashLoopBackOff
- Fügt `victoriametrics-metrics-datasource` zu `grafana.plugins` hinzu, damit es via
  Init-Container installiert wird bevor Grafana startet

## Test plan

- [ ] ArgoCD Sync wendet das aktualisierte Deployment an
- [ ] Grafana Pod startet ohne CrashLoopBackOff
- [ ] Datasource `VictoriaMetrics (DS)` ist in Grafana verfügbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)